### PR TITLE
bionic: Support wildcards in cached hosts file

### DIFF
--- a/libc/dns/net/hosts_cache.c
+++ b/libc/dns/net/hosts_cache.c
@@ -121,7 +121,7 @@ static int cmp_hcent_name(const void *a, const void *b)
 	return hstrcmp(na, nb);
 }
 
-static struct hcent *_hcfindname(const char *name)
+static struct hcent *_hcfindname_exact(const char *name)
 {
 	size_t first, last, mid;
 	struct hcent *cur = NULL;
@@ -160,6 +160,33 @@ found:
 	}
 
 	return cur;
+}
+
+static struct hcent *_hcfindname(const char *name)
+{
+	struct hcent *ent;
+	char namebuf[MAX_HOSTLEN];
+	char *p;
+	char *dot;
+
+	ent = _hcfindname_exact(name);
+	if (!ent && strlen(name) < sizeof(namebuf)) {
+		strcpy(namebuf, name);
+		p = namebuf;
+		do {
+			dot = strchr(p, '.');
+			if (!dot)
+				break;
+			if (dot > p) {
+				*(dot - 1) = '*';
+				ent = _hcfindname_exact(dot - 1);
+			}
+			p = dot + 1;
+		}
+		while (!ent);
+	}
+
+	return ent;
 }
 
 /*


### PR DESCRIPTION
If an exact name is not found in the hosts file and the host name
contains at least one dot, search for entries of the form "*.domain",
where domain is the portion of the host name after the first dot.  If
that is not found, repeat using the domain.

Example: a.b.c.example.com would search for the following in turn:
	a.b.c.example.com
	*.b.c.example.com
	*.c.example.com
	*.example.com
	*.com

Change-Id: I4b0bb81699151d5b371850daebf785e35ec9b180